### PR TITLE
Remove armv7 as a framework architecture for Carthage compatibility (…

### DIFF
--- a/build_configs/CardIO_Framework.xcconfig
+++ b/build_configs/CardIO_Framework.xcconfig
@@ -4,7 +4,7 @@
 //
 //
 
-ARCHS = arm64 armv7 armv7s
+ARCHS = arm64 armv7s
 ONLY_ACTIVE_ARCH = NO
 
 GCC_VERSION = com.apple.compilers.llvm.clang.1_0


### PR DESCRIPTION
…0.33.0) and Xcode (10.2)

This commit adjusts one thing: instructing Xcode to not build for the effectively defunct armv7 architecture (not used since iPhone 5). This allows carthage to successfully build the card-io framework. We can roll this back in the future if Carthage ever fixes the bug. Here is an issue from the carthage repo dancing around the root cause I think: https://github.com/Carthage/Carthage/issues/2738