### PR TITLE
Undo all arch settings

### DIFF
--- a/build_configs/CardIO_Framework.xcconfig
+++ b/build_configs/CardIO_Framework.xcconfig
@@ -4,7 +4,6 @@
 //
 //
 
-ARCHS = arm64 armv7s
 ONLY_ACTIVE_ARCH = NO
 
 GCC_VERSION = com.apple.compilers.llvm.clang.1_0


### PR DESCRIPTION
This change has already been tested in the incoming branch (`nteissler`) for this CR. This PR brings the changes to our affirm fork so Carthage can point to that and not nteissler